### PR TITLE
:sparkle: Add table layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/DerGut/zomdb
 
 go 1.22
 
-require github.com/spf13/afero v1.9.2
+require (
+	github.com/fxamacker/cbor/v2 v2.7.0
+	github.com/spf13/afero v1.9.2
+)
 
-require golang.org/x/text v0.3.4 // indirect
+require (
+	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/text v0.3.4 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -132,6 +134,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -1,12 +1,11 @@
 package table
 
 import (
-	"bytes"
-	"encoding/gob"
 	"errors"
 	"fmt"
 
 	"github.com/DerGut/zomdb/pkg/heap"
+	"github.com/fxamacker/cbor/v2"
 )
 
 type Table struct {
@@ -171,23 +170,16 @@ func (t *Table) buildKey(values []any) ([]byte, error) {
 }
 
 func encode(a []any) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(a); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return cbor.Marshal(a)
 }
 
 func decode(p []byte) ([]any, error) {
-	r := bytes.NewReader(p)
-
-	var v []any
-	if err := gob.NewDecoder(r).Decode(&v); err != nil {
+	var values []any
+	if err := cbor.Unmarshal(p, &values); err != nil {
 		return nil, err
 	}
 
-	return v, nil
+	return values, nil
 }
 
 func validateColumnType(value any, colType ColumnType) error {

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/DerGut/zomdb/pkg/table"
 )
 
-func TestTable_New(t *testing.T) {
+func TestTable(t *testing.T) {
 	spec := table.Spec{
 		Name: filepath.Join(t.TempDir(), "test"),
 		Columns: []table.Column{
@@ -59,5 +59,14 @@ func TestTable_New(t *testing.T) {
 
 	if name != "bar" {
 		t.Fatalf("Expected %q, got %q", "bar", name)
+	}
+
+	amount, ok := row[2].(uint64)
+	if !ok {
+		t.Fatalf("Expected int type, got %T", row[2])
+	}
+
+	if amount != 16 {
+		t.Fatalf("Expected %d, got %d", 16, amount)
 	}
 }


### PR DESCRIPTION
Rows are encoded as single value using CBOR. The `gob` package introduced 0 bytes with mess with C strings in the current implementation.

This also replaces an older experiment to build a table layer on top of LSM trees.